### PR TITLE
Canned reports modified according to ETL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: avni-server
     image: vind3v/avni-server:3.21.1
     ports:
-      - "8021:8021"
+      - "8022:8022"
       - "3000:3000"
     depends_on:
       - db

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "avni-canned-reports",
   "version": "1.0.3",
-  "private": false,
-  "proxy": "http://localhost:8021",
+  "proxy": "http://localhost:8022",
   "homepage": "/analytics",
   "dependencies": {
     "@emotion/react": "^11.6.0",
@@ -15,6 +14,7 @@
     "@nivo/bar": "^0.74.0",
     "@nivo/calendar": "^0.74.0",
     "@nivo/core": "^0.74.0",
+    "@nivo/line": "^0.83.0",
     "@nivo/pie": "^0.74.0",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",

--- a/src/Dashboards/ActivitiesDashboard.js
+++ b/src/Dashboards/ActivitiesDashboard.js
@@ -1,108 +1,18 @@
 import React, {Fragment, useEffect, useState} from 'react';
 import apis from '../api';
-import ActivityCalender from "../components/ActivityCalender";
-import ActivityPieChart from "../components/ActivityPieChart";
+import DataTable from "../components/DataTable";
 import ReportFilters from "../components/ReportFilters";
 import Grid from "@mui/material/Grid";
 import {map} from 'lodash';
 
-const Activities = ({
-                        daywiseActivities,
-                        registrations,
-                        enrolments,
-                        completedVisits,
-                        cancelledVisits,
-                        onTimeVisits,
-                        programExits
-                    }) => {
-    return (
-        <div style={{display: 'flex', flexDirection: 'column', alignItems: 'flexStart'}}>
-            <ActivityCalender
-                data={daywiseActivities.data}
-                title={'Day wise activities'}
-                loading={daywiseActivities.loading}
-            />
-            <Grid container direction={'row'} spacing={2}>
-                <Grid item xs={6}>
-                    <ActivityPieChart
-                        loading={registrations.loading}
-                        data={registrations.data}
-                        chartName={'Registrations'}
-                        height={350}
-                    />
-                </Grid>
-                <Grid item xs={6}>
-                    <ActivityPieChart
-                        loading={enrolments.loading}
-                        data={enrolments.data}
-                        chartName={'Program enrolments'}
-                        height={350}
-                    />
-                </Grid>
-            </Grid>
-            <Grid container direction={'row'} spacing={2}>
-                <Grid item xs={6}>
-                    <ActivityPieChart
-                        loading={programExits.loading}
-                        data={programExits.data}
-                        chartName={'Program exits'}
-                        height={350}
-                    />
-                </Grid>
-                <Grid item xs={6}>
-                    <ActivityPieChart
-                        loading={completedVisits.loading}
-                        data={completedVisits.data}
-                        chartName={'Visits'}
-                        height={350}
-                    />
-                </Grid>
-            </Grid>
-            <Grid container direction={'row'} spacing={2}>
-                <Grid item xs={6}>
-                    <ActivityPieChart
-                        loading={onTimeVisits.loading}
-                        data={onTimeVisits.data}
-                        chartName={'On time visits'}
-                        height={350}
-                    />
-                </Grid>
-                <Grid item xs={6}>
-                    <ActivityPieChart
-                        loading={cancelledVisits.loading}
-                        data={cancelledVisits.data}
-                        chartName={'Cancelled visits'}
-                        height={350}
-                    />
-                </Grid>
-            </Grid>
-        </div>
-    )
-};
-
 export default function ActivitiesReportScreen() {
 
-    const [daywiseActivities, setDaywiseActivities] = useState({loading: true, data: []});
-    const [registrations, setRegistrations] = useState({loading: true, data: []});
-    const [enrolments, setEnrolments] = useState({loading: true, data: []});
-    const [completedVisits, setCompletedVisits] = useState({loading: true, data: []});
-    const [cancelledVisits, setCancelledVisits] = useState({loading: true, data: []});
-    const [onTimeVisits, setOnTimeVisits] = useState({loading: true, data: []});
-    const [programExits, setProgramExits] = useState({loading: true, data: []});
+    const summaryTableRef = React.createRef();
     const [loading, setLoading] = useState(true);
-    const activityTypeToDispatcherMap = {
-        "daywiseActivities": setDaywiseActivities,
-        "registrations": setRegistrations,
-        "enrolments": setEnrolments,
-        "onTimeVisits": setOnTimeVisits,
-        "programExits": setProgramExits,
-        "completedVisits": setCompletedVisits,
-        "cancelledVisits": setCancelledVisits,
-    };
 
     function fetchData(queryString = "") {
         Promise.all(map(
-            activityTypeToDispatcherMap,
+            // activityTypeToDispatcherMap,
             (setState, type) => Promise.resolve(
                 apis.fetchActivity(type, queryString).then(({data}) => setState({loading: false, data}))
             ))
@@ -114,18 +24,25 @@ export default function ActivitiesReportScreen() {
         // eslint-disable-next-line
     }, []);
 
+
     return (
         <Fragment>
             <ReportFilters onApply={(queryString) => fetchData(queryString)} disableFilter={loading} displayTypeFilter/>
-            <Activities
-                daywiseActivities={daywiseActivities}
-                registrations={registrations}
-                enrolments={enrolments}
-                completedVisits={completedVisits}
-                cancelledVisits={cancelledVisits}
-                onTimeVisits={onTimeVisits}
-                programExits={programExits}
-            />
+            <div style={{display: 'flex', flexDirection: 'column', alignItems: 'flexStart'}}>
+                <Grid item xs={12}>
+                    <DataTable
+                        tableRef={summaryTableRef}
+                        title={'Summary of Organisation Tables'}
+                        columns={[
+                            {title: 'Name', field: 'tableName'},
+                            {title: 'Type', field: 'tableType'},
+                            {title: 'Link to detailed analysis'},
+                        ]}
+                        fetchData={apis.fetchSummaryTable}
+                        onResolve={data => ({data})}
+                    />
+                </Grid>
+        </div>
         </Fragment>
     )
 }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -20,20 +20,19 @@ const getData = (url) => get(url).then(res => res.data);
 
 const apis = {
     fetchActivity: (type, queryString) => getData(`/report/aggregate/activity?type=${type}&${queryString}`),
+    fetchSummaryTable: (filterQuery) => getData(`/report/aggregate/summaryTable?${filterQuery}`),
     fetchForms: () => getData("/web/forms?size=500").then(res => res._embedded.basicFormDetailses),
     searchConcepts: (queryString) => getData(`/search/concept?${queryString}`),
     fetchOperationalModules: () => getData('/web/operationalModules'),
     fetchFormData: (form, queryString) => getData(`/report/aggregate/codedConcepts?formUUID=${form.uuid}&${queryString}`),
     fetchLocations: () => getData('/locations/web/getAll'),
-    fetchUserActivities: (filterQuery) => getData(`/report/hr/overallActivities?${filterQuery}`),
+    fetchUserActivities: (filterQuery) => getData(`/report/hr/userActivity?${filterQuery}`),
     fetchUserSyncFailures: (filterQuery) => getData(`/report/hr/syncFailures?${filterQuery}`),
     fetchUserAppVersions: (queryString) => getData(`/report/hr/appVersions?${queryString}`),
     fetchUserDeviceModels: (queryString) => getData(`/report/hr/deviceModels?${queryString}`),
     fetchUserDetails: (filterQuery) => getData(`/report/hr/userDetails?${filterQuery}`),
-    fetchSyncTelemetry: (filterQuery, queryString) => getData(`/report/syncTelemetry?${queryString}&${filterQuery}`),
-    fetchChampionUsers: (queryString) => getData(`/report/hr/championUsers?${queryString}`),
-    fetchNonPerformingUsers: (queryString) => getData(`/report/hr/nonPerformingUsers?${queryString}`),
-    fetchUserCancellingVisits: (queryString) => getData(`/report/hr/mostCancelled?${queryString}`),
+    fetchSyncTelemetry: (filterQuery, queryString) => getData(`/report/hr/latestSyncs?${queryString}&${filterQuery}`),
+    fetchMedianSync: (filterQuery) => getData(`/report/hr/medianSync?${filterQuery}`),
     fetchUserGroups: () => getData('/web/groups'),
     fetchCommonUserIds: (filterQuery) => getData(`/report/hr/commonUserIds?${filterQuery}`)
 };


### PR DESCRIPTION
1) canned reports now listening to port 8022 (avni-etl) instead of avni-server
2) Added new tables - weekly median sync time and latest sync in HR tab and summary table in Activities tab
3) Removed other tables from Activities tab as they didn't provide useful visualization from ETL
4) Removed Sync Telemetry table, %visits and cancelled visits table as these slowed down the query time and weren't that useful
5) Modified other tables on HR tab according to ETL

https://github.com/avniproject/avni-product/issues/1334